### PR TITLE
ENH: add source to all covid scrapers

### DIFF
--- a/src/cmdc_tools/datasets/base.py
+++ b/src/cmdc_tools/datasets/base.py
@@ -9,7 +9,8 @@ import pandas as pd
 
 
 class DatasetBase:
-    autodag = True
+    autodag: bool = True
+    data_type: str = "general"
 
     def __init__(self):
         pass

--- a/src/cmdc_tools/datasets/official/AK/__init__.py
+++ b/src/cmdc_tools/datasets/official/AK/__init__.py
@@ -34,9 +34,10 @@ def _find_col_by_prefix(df, col_prefix):
     return cols[0]
 
 
-class Alaska(CountyData, DatasetBaseNoDate):
+class Alaska(DatasetBaseNoDate, CountyData):
     table_name = "us_covid"
     pk = '("vintage", "dt", "fips", "variable_id")'
+    source = "https://www.arcgis.com/apps/opsdashboard/index.html#/83c63cfec8b24397bdf359f49b11f218"
 
     def get_cases(self):
         url = "https://www.arcgis.com/sharing/rest/content/items/"

--- a/src/cmdc_tools/datasets/official/AR/data.py
+++ b/src/cmdc_tools/datasets/official/AR/data.py
@@ -4,10 +4,12 @@ import pandas as pd
 import requests
 
 from ..base import ArcGIS
+from ...base import DatasetBaseNoDate
 
 
-class Arkansas(ArcGIS):
+class Arkansas(DatasetBaseNoDate, ArcGIS):
     ARCGIS_ID = "PwY9ZuZRDiI5nXUB"
+    source = "https://experience.arcgis.com/experience/c2ef4a4fcbe5458fbf2e48a21e4fece9"
 
     def __init__(self, params=None):
 

--- a/src/cmdc_tools/datasets/official/CA/counties/imperial.py
+++ b/src/cmdc_tools/datasets/official/CA/counties/imperial.py
@@ -5,7 +5,7 @@ from ... import ArcGIS
 from .... import DatasetBaseNoDate
 
 
-class Imperial(ArcGIS, DatasetBaseNoDate):
+class Imperial(DatasetBaseNoDate, ArcGIS):
     """
     Imperial publishes their county level data in a dashboard that can
     be found at:
@@ -25,6 +25,9 @@ class Imperial(ArcGIS, DatasetBaseNoDate):
 
     ARCGIS_ID = "RomaVqqozKczDNgd"
     FIPS = 6073
+    source = (
+        "http://www.icphd.org/health-information-and-resources/healthy-facts/covid-19/"
+    )
 
     def __init__(self):
         self.hospitaloutfields = {

--- a/src/cmdc_tools/datasets/official/CA/counties/la.py
+++ b/src/cmdc_tools/datasets/official/CA/counties/la.py
@@ -73,7 +73,11 @@ async def test_data():
     ]
 
 
-class LA(CountyData, DatasetBaseNoDate):
+class LA(DatasetBaseNoDate, CountyData):
+    source = (
+        "http://dashboard.publichealth.lacounty.gov/covid19_surveillance_dashboard/"
+    )
+
     def get(self):
         df = asyncio.run(test_data())
         return (

--- a/src/cmdc_tools/datasets/official/CA/counties/sandiego.py
+++ b/src/cmdc_tools/datasets/official/CA/counties/sandiego.py
@@ -5,7 +5,7 @@ from ... import ArcGIS
 from .... import DatasetBaseNoDate
 
 
-class SanDiego(ArcGIS, DatasetBaseNoDate):
+class SanDiego(DatasetBaseNoDate, ArcGIS):
     """
     San Diego publishes their county level data in a dashboard that can
     be found at:
@@ -21,6 +21,10 @@ class SanDiego(ArcGIS, DatasetBaseNoDate):
 
     ARCGIS_ID = "1vIhDJwtG5eNmiqX"
     FIPS = 6073
+    source = (
+        "https://www.sandiegocounty.gov/content/sdc/hhsa/programs"
+        "/phs/community_epidemiology/dc/2019-nCoV/status.html"
+    )
 
     def __init__(self, params=None):
         # Default parameter values

--- a/src/cmdc_tools/datasets/official/CA/data.py
+++ b/src/cmdc_tools/datasets/official/CA/data.py
@@ -21,7 +21,9 @@ C_RENAMER = {
 }
 
 
-class CACountyData(CountyData, DatasetBaseNoDate):
+class CACountyData(DatasetBaseNoDate, CountyData):
+    source = CA_COUNTY_URL
+
     def _insert_query(self, df, table_name, temp_name, pk):
         out = f"""
         INSERT INTO data.{table_name} (vintage, dt, fips, variable_id, value)

--- a/src/cmdc_tools/datasets/official/KY/data.py
+++ b/src/cmdc_tools/datasets/official/KY/data.py
@@ -4,8 +4,12 @@ from ...base import DatasetBaseNoDate
 from ..base import ArcGIS
 
 
-class Kentucky(ArcGIS, DatasetBaseNoDate):
+class Kentucky(DatasetBaseNoDate, ArcGIS):
     ARCGIS_ID = ""
+    source = (
+        "https://kygeonet.maps.arcgis.com/apps/opsdashboard/"
+        "index.html#/543ac64bc40445918cf8bc34dc40e334"
+    )
 
     def arcgis_query_url(self, service, sheet, srvid=1):
         out = f"https://kygisserver.ky.gov/arcgis/rest/services/WGS84WM_Services/{service}/FeatureServer/{sheet}/query"

--- a/src/cmdc_tools/datasets/official/MA/__init__.py
+++ b/src/cmdc_tools/datasets/official/MA/__init__.py
@@ -8,8 +8,12 @@ from .. import CountyData
 from ... import DatasetBaseNeedsDate
 
 
-class Massachusetts(CountyData, DatasetBaseNeedsDate):
+class Massachusetts(DatasetBaseNeedsDate, CountyData):
     start_date = "2020-04-29"
+    source = (
+        "https://www.mass.gov/info-details/"
+        "covid-19-response-reporting#covid-19-daily-dashboard-"
+    )
 
     def _insert_query(self, df: pd.DataFrame, table_name: str, temp_name: str, pk: str):
         return f"""

--- a/src/cmdc_tools/datasets/official/MD/data.py
+++ b/src/cmdc_tools/datasets/official/MD/data.py
@@ -32,8 +32,9 @@ MD_COUNTY_NF_MAP = {
 }
 
 
-class Maryland(ArcGIS, DatasetBaseNoDate):
+class Maryland(DatasetBaseNoDate, ArcGIS):
     ARCGIS_ID = "njFNhDsUCentVYJW"
+    source = "https://coronavirus.maryland.gov/"
 
     def __init__(self, params=None):
 

--- a/src/cmdc_tools/datasets/official/MT/data.py
+++ b/src/cmdc_tools/datasets/official/MT/data.py
@@ -6,7 +6,12 @@ from ..base import ArcGIS
 from ...base import DatasetBaseNoDate
 
 
-class Montana(ArcGIS, DatasetBaseNoDate):
+class Montana(DatasetBaseNoDate, ArcGIS):
+    source = (
+        "https://montana.maps.arcgis.com/apps/MapSeries"
+        "/index.html?appid=7c34f3412536439491adcc2103421d4b"
+    )
+
     def __init__(self, params=None):
         self.ARCGIS_ID = "qnjIrwR8z5Izc0ij"
 

--- a/src/cmdc_tools/datasets/official/NE/data.py
+++ b/src/cmdc_tools/datasets/official/NE/data.py
@@ -5,8 +5,12 @@ from ...base import DatasetBaseNoDate
 from ..base import ArcGIS
 
 
-class Nebraska(ArcGIS, DatasetBaseNoDate):
+class Nebraska(DatasetBaseNoDate, ArcGIS):
     ARCGIS_ID = ""
+    source = (
+        "https://nebraska.maps.arcgis.com/apps/opsdashboard/"
+        "index.html#/4213f719a45647bc873ffb58783ffef3"
+    )
 
     def __init__(self, params=None):
 

--- a/src/cmdc_tools/datasets/official/NJ/data.py
+++ b/src/cmdc_tools/datasets/official/NJ/data.py
@@ -18,7 +18,7 @@ _NJ_PPA_COLS = {
 }
 
 
-class NewJersey(ArcGIS, DatasetBaseNoDate):
+class NewJersey(DatasetBaseNoDate, ArcGIS):
     """
     Notes:
 
@@ -27,6 +27,7 @@ class NewJersey(ArcGIS, DatasetBaseNoDate):
     """
 
     ARCGIS_ID = "Z0rixLlManVefxqY"
+    source = "https://covid19.nj.gov/#live-updates"
 
     def __init__(self, params=None):
         super().__init__(params=params)

--- a/src/cmdc_tools/datasets/official/PA/data.py
+++ b/src/cmdc_tools/datasets/official/PA/data.py
@@ -5,8 +5,12 @@ from ...base import DatasetBaseNoDate
 from ..base import ArcGIS
 
 
-class Pennsylvania(ArcGIS, DatasetBaseNoDate):
+class Pennsylvania(DatasetBaseNoDate, ArcGIS):
     ARCGIS_ID = "xtuWQvb2YQnp0z3F"
+    source = (
+        "https://www.arcgis.com/apps/opsdashboard/"
+        "index.html#/85054b06472e4208b02285b8557f24cf"
+    )
 
     def _insert_query(self, df: pd.DataFrame, table_name: str, temp_name: str, pk: str):
         out = f"""

--- a/src/cmdc_tools/datasets/official/base.py
+++ b/src/cmdc_tools/datasets/official/base.py
@@ -8,6 +8,7 @@ from .. import InsertWithTempTable
 class CountyData(InsertWithTempTable):
     table_name = "us_covid"
     pk = '("vintage", "dt", "fips", "variable_id")'
+    data_type = "covid"
 
     def __init__(self):
         super(CountyData, self).__init__()

--- a/src/tests/test_datasets.py
+++ b/src/tests/test_datasets.py
@@ -3,7 +3,12 @@ import pytest
 import pandas as pd
 
 
-@pytest.mark.parametrize("cls", datasets.DatasetBaseNoDate.__subclasses__())
+nodates = datasets.DatasetBaseNoDate.__subclasses__()
+yesdates = datasets.DatasetBaseNeedsDate.__subclasses__()
+all_ds = nodates + yesdates
+
+
+@pytest.mark.parametrize("cls", nodates)
 def test_no_date_datasets(cls):
     if cls is datasets.WEI:
         print("Skipping!")
@@ -15,9 +20,20 @@ def test_no_date_datasets(cls):
     assert out.shape[0] > 0
 
 
-@pytest.mark.parametrize("cls", datasets.DatasetBaseNeedsDate.__subclasses__())
+@pytest.mark.parametrize("cls", yesdates)
 def test_need_date_datasets(cls):
     d = cls()
     out = d.get("2020-05-25")
     assert isinstance(out, pd.DataFrame)
     assert out.shape[0] > 0
+
+
+@pytest.mark.parametrize("cls", all_ds)
+def test_all_dataset_has_type(cls):
+    assert hasattr(cls, "data_type")
+
+
+@pytest.mark.parametrize("cls", all_ds)
+def test_covid_dataset_has_source(cls):
+    if getattr(cls, "data_type", False) == "covid":
+        assert hasattr(cls, "source")


### PR DESCRIPTION
This PR ensures that all scrapers have a `data_type` field. Right now this is a string that is either `"general"` or `"covid"` depending on whether or not the scraper obtains covid-specific data.

For all `data_type == "covid"` sources, I also added a `source` attribute that points to the url of the source.

There are tests that ensure these things are in place so CI will catch us if we forget to add `source`