### PR TITLE
Schema tablename

### DIFF
--- a/schemas/sources.sql
+++ b/schemas/sources.sql
@@ -18,3 +18,21 @@ CREATE OR REPLACE VIEW meta.latest_covid_source as
     select location, variable_id, date_accessed, source
 from max_date
 left join data.covid_sources using (location, variable_id, date_accessed);
+
+
+alter table data.covid_sources add column table_name text not null default 'us_covid';
+
+update data.covid_sources set table_name='jhu_daily_reports'
+where source = 'https://github.com/CSSEGISandData/COVID-19';
+
+update data.covid_sources set table_name='jhu_daily_reports_us'
+where source = 'https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_daily_reports_us';
+
+update data.covid_sources set table_name = 'usafacts_covid'
+    where source = 'https://usafacts.org/issues/coronavirus/';
+
+update data.covid_sources set table_name = 'nyt_covid'
+    where source = 'https://github.com/nytimes/covid-19-data';
+
+create index covid_sources__table_name_idx
+	on data.covid_sources (table_name);

--- a/src/cmdc_tools/datasets/base.py
+++ b/src/cmdc_tools/datasets/base.py
@@ -11,6 +11,7 @@ import pandas as pd
 class DatasetBase:
     autodag: bool = True
     data_type: str = "general"
+    table_name: str
 
     def __init__(self):
         pass
@@ -85,8 +86,8 @@ class DatasetBase:
 
         temp_table = "__covid_sources_{}".format(str(random.randint(1000, 9999)))
         sql = f"""
-        INSERT INTO data.covid_sources(date_accessed, location, variable_id, source)
-        SELECT tt.this_date, ff.fips, mv.id, tt.src
+        INSERT INTO data.covid_sources(date_accessed, location, variable_id, source, table_name)
+        SELECT tt.this_date, ff.fips, mv.id, tt.src, '{self.table_name}'
         from {temp_table} tt
         {join_locs}
         {join_covid}
@@ -144,7 +145,6 @@ def _build_on_conflict_do_nothing_query(
 
 class InsertWithTempTable(DatasetBase, ABC):
     pk: str
-    table_name: str
 
     def _insert_query(self, df: pd.DataFrame, table_name: str, temp_name: str, pk: str):
 


### PR DESCRIPTION
This PR adds `table_name` to the data.covid_sources  table

It also adjusts the `log_covid_source` function to automatically add the table name

NOTE: I have already made the sql changes live and I included the alter table + update queries for full reference. if we were starting over we'd probably have the column created when the table is created, but this will be equivalent.