### PR TITLE
FIX: Updates to geo and CTP

### DIFF
--- a/src/cmdc_tools/datasets/covidtrackingproject/data.py
+++ b/src/cmdc_tools/datasets/covidtrackingproject/data.py
@@ -3,7 +3,6 @@ import requests
 import textwrap
 
 from .. import InsertWithTempTable, DatasetBaseNoDate
-from ..uscensus.geo import FIPS_RESTRICT_QUERY
 
 
 CURRENT_URL = "https://covidtracking.com/api/v1/states/current.json"
@@ -73,6 +72,5 @@ class CTP(InsertWithTempTable, DatasetBaseNoDate):
             var_name="variable_name",
             value_name="value",
         ).dropna()
-        df = df.query(FIPS_RESTRICT_QUERY)
 
         return df

--- a/src/cmdc_tools/datasets/usafacts/data.py
+++ b/src/cmdc_tools/datasets/usafacts/data.py
@@ -40,8 +40,15 @@ class USAFactsCases(InsertWithTempTable, DatasetBaseNoDate):
         # Load data from site and move dates from column names to
         # a new variable
         df = pd.read_csv(BASEURL + self.filename)
-        df = df.drop(["County Name", "State"], axis=1).melt(
-            id_vars=["countyFIPS", "stateFIPS"], var_name="dt", value_name="value"
+        cols = ["countyFIPS", "County Name", "State", "stateFIPS"]
+        cols = cols + [c for c in df.columns if c[-2:] == "20"]
+
+        df = (
+            df.loc[:, cols]
+            .drop(["County Name", "State"], axis=1)
+            .melt(
+                id_vars=["countyFIPS", "stateFIPS"], var_name="dt", value_name="value"
+            )
         )
         df["dt"] = pd.to_datetime(df["dt"])
 

--- a/src/cmdc_tools/datasets/uscensus/geo.py
+++ b/src/cmdc_tools/datasets/uscensus/geo.py
@@ -49,7 +49,6 @@ def _download_shape_file(apiurl: str, filename: str):
     gdf["INTPTLAT"] = pd.to_numeric(gdf["INTPTLAT"])
     gdf["INTPTLON"] = pd.to_numeric(gdf["INTPTLON"])
     gdf.columns = [c.lower() for c in gdf.columns]
-    gdf.columns = [c.lower() for c in gdf.columns]
 
     return gdf
 


### PR DESCRIPTION
This PR does two things:

1. It fixes the error that the `name` column from the USCensus TIGER shape files ignores the "City" word from counties like St. Louis City which creates a duplicate of St. Louis (county) and St. Louis City (county).
2. Adds a new table for covidtracking project (rather than keeping their data in our official source covid table) and adds the corresponding API endpoint.